### PR TITLE
Saves

### DIFF
--- a/lib/tarona/act.rb
+++ b/lib/tarona/act.rb
@@ -3,8 +3,23 @@ module Tarona
   #
   # Events:
   #
-  # * `end` - you must trigger it when the act execution is ended. Argument: the identificator of the next act
+  # * `end` - you must trigger it when the act execution is ended.
+  #   Argument: the identificator of the next act
   class Act < Tardvig::Act
     include Tardvig::Events
+
+    private
+
+    def execute
+      deal_with_display
+      process
+    end
+
+    def deal_with_display
+      sender_proc = proc { notify_display }
+      @io.on :update_io, &sender_proc
+      on_first(:end) { @io.remove_listener :update_io, sender_proc }
+      notify_display
+    end
   end
 end

--- a/lib/tarona/doorman.rb
+++ b/lib/tarona/doorman.rb
@@ -5,7 +5,7 @@ module Tarona
   # Instances of this class should be used as Rack application object.
   class Doorman
     # @return [Hash] `game.hash => game` pairs.
-    #   `game` is instance of `game` option of {#new}
+    #   `game` is instance of `game` option of {#initialize}
     attr_reader :sessions
 
     # Create a new doorman. You should pass the returned value to the Rack's

--- a/lib/tarona/doorman.rb
+++ b/lib/tarona/doorman.rb
@@ -4,6 +4,10 @@ module Tarona
   #
   # Instances of this class should be used as Rack application object.
   class Doorman
+    # @return [Hash] `game.hash => game` pairs.
+    #   `game` is instance of `game` option of {#new}
+    attr_reader :sessions
+
     # Create a new doorman. You should pass the returned value to the Rack's
     # `run` method.
     # @option params [Class] :io class which can handle WebSocket connections.
@@ -20,6 +24,7 @@ module Tarona
     # @return [Doorman] new instancee
     def initialize(params)
       @params = params
+      @sessions = {}
     end
 
     # This method is created for Rack to call it when a new connection is
@@ -27,11 +32,20 @@ module Tarona
     def call(env)
       if @params[:io].player?(env)
         io = @params[:io].new env
-        options = @params[:game_options].merge io: io
-        io.on(:open) { @params[:game].call options }
+        open_game_inst io
         io.response
       else
         @params[:server].call env
+      end
+    end
+
+    private
+
+    def open_game_inst(io)
+      io.on_first :open do
+        options = @params[:game_options].merge io: io
+        game_inst = @params[:game].call options
+        sessions[game_inst.hash] = game_inst
       end
     end
   end

--- a/lib/tarona/play.rb
+++ b/lib/tarona/play.rb
@@ -41,9 +41,11 @@ module Tarona
       RunActs.call(
         acts: @acts,
         first_act: @first_act,
-        act_params: { io: @io, tk: @tk_instance })
+        session: @tk_instance.session,
+        act_params: { io: @io, tk: @tk_instance }
+      )
     end
-    
+
     def prepare
       @tk_instance = @tk.new
     end

--- a/lib/tarona/web_socket.rb
+++ b/lib/tarona/web_socket.rb
@@ -2,6 +2,8 @@ module Tarona
   # Instances of this class are event-driven WebSocket connections using the
   # GameIO interface.
   class WebSocket < Tardvig::GameIO
+    attr_reader :socket
+
     def self.player?(env)
       Faye::WebSocket.websocket? env
     end
@@ -22,6 +24,7 @@ module Tarona
       # I do not know whether it is possible.
       @socket = value
       set_socket_listeners
+      classic_happen :update_io
     end
 
     alias classic_happen happen

--- a/public/scripts/game_engine.js
+++ b/public/scripts/game_engine.js
@@ -107,10 +107,10 @@ function Messenger(url) {
 
   var self = this;
   this.socket.onmessage = function(msg) {
-    var msg_content = JSON.parse(msg.data);
-    self.listeners(msg_content[0]).forEach(function(listener) {
-      if (listener) listener.apply(self, [msg_content[1]]);
-    });
+    pure_happen.apply(self, JSON.parse(msg.data));
+  };
+  this.socket.onopen = function() {
+    pure_happen.apply(self, ['open']);
   };
 }
 

--- a/public/scripts/runner.js
+++ b/public/scripts/runner.js
@@ -13,6 +13,14 @@ function Runner() {
    * @type Messenger
    */
   this.messenger = new Messenger(location.origin.replace(/^http/, 'ws'));
+  this.messenger.on('open', function() {
+    var session_id = document.cookie.match(/session_id=([-a-zA-Z0-9]+)(;|$)/);
+    if (session_id) session_id = session_id[1];
+    this.happen('display_ready', { session_id: session_id });
+  });
+  this.messenger.on('new_session', function(inf) {
+    document.cookie = 'session_id=' + inf.hash;
+  });
   this.messenger.on('act_start', function(act) {
     runner.display.generate(act.type, act);
   });

--- a/spec/act_spec.rb
+++ b/spec/act_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Tarona::Act do
-  let(:act) { described_class.new }
+  let(:io) { Object.new.extend Tardvig::Events }
+  let(:act) { described_class.new io: io }
 
   it 'inherits the tardvig act' do
     expect(described_class.superclass).to be(Tardvig::Act)
@@ -7,5 +8,24 @@ RSpec.describe Tarona::Act do
 
   it 'include events' do
     expect(act).to be_a_kind_of(Tardvig::Events)
+  end
+
+  it 'send its displayed data when it is started' do
+    expect(io).to receive(:happen).with(:act_start, kind_of(Hash))
+    act.call
+  end
+
+  it 'send its displayed data when io is updated' do
+    act.call
+    expect(io).to receive(:happen).with(:update_io).ordered.and_call_original
+    expect(io).to receive(:happen).with(:act_start, kind_of(Hash)).ordered
+    io.happen :update_io
+  end
+
+  it 'does not send its displayed data after end' do
+    act.call
+    expect(io).not_to receive(:happen).with(:act_start, kind_of(Hash))
+    act.happen :end
+    io.happen :update_io
   end
 end

--- a/spec/doorman_spec.rb
+++ b/spec/doorman_spec.rb
@@ -1,29 +1,34 @@
 RSpec.describe Tarona::Doorman do
-  let(:io) { double }
-  let(:io_instance) { double }
-  let(:server) { double }
-  let(:game) { double }
+  %w(io io_instance server game game_inst env).each do |o|
+    let(o.to_sym) { double o }
+  end
   let(:options) { { valid: true } }
-  let(:env) { double }
+  let(:socket) { double 'socket' }
+  let(:display_options) { {} }
   let :doorman do
     described_class.new(
-        io: io,
-        server: server,
-        game: game,
-        game_options: options
+      io: io,
+      server: server,
+      game: game,
+      game_options: options
     )
   end
 
   before :example do
     allow(io).to receive(:new).with(env) { io_instance }
     allow(io_instance).to receive(:on_first) do |event, &block|
-      if event == :open
-        block.call
-      else
-        raise "Unexpected event: #{event.inspect}"
-      end
+      events = [:display_ready]
+      raise "Unexpected event: #{event.inspect}" unless events.include? event
+      block.call display_options
+    end
+    allow(io_instance).to receive(:happen) do |event|
+      events = [:new_session]
+      raise "Unexpected event: #{event.inspect}" unless events.include? event
     end
     allow(io_instance).to receive(:response) { 'foo' }
+    allow(io_instance).to receive(:socket) {  }
+    allow(game).to receive(:call) { game_inst }
+    allow(game_inst).to receive(:io) { io_instance }
   end
 
   describe '#call' do
@@ -43,14 +48,47 @@ RSpec.describe Tarona::Doorman do
       expect(io_instance).to receive(:response) { 'foo' }
       expect(doorman.call(env)).to eq('foo')
     end
+
+    it 'send session hash through io if there is new one' do
+      expect(io).to receive(:player?) { true }
+      expect(io_instance).to receive(:happen).with(
+        :new_session, hash: game_inst.hash.to_s(16)
+      )
+      doorman.call env
+    end
+
+    it 'use old session if it is' do
+      new_socket = io_instance.socket
+      expect(io).to receive(:player?).and_return(true).twice
+      doorman.call env
+      display_options[:session_id] = game_inst.hash.to_s(16)
+      expect(io_instance).not_to receive(:happen)
+      expect(io_instance).to receive(:socket=).with(new_socket)
+      doorman.call env
+    end
+
+    it 'does not use old session unless it is given' do
+      expect(io).to receive(:player?).and_return(true).twice
+      doorman.call env
+      expect(io_instance).to receive(:happen)
+      expect(io_instance).not_to receive(:socket=)
+      doorman.call env
+    end
+
+    it 'does not use old session unless it exists' do
+      expect(io).to receive(:player?).and_return(true).twice
+      doorman.call env
+      display_options[:session_id] = 'foobarbaz'
+      expect(io_instance).to receive(:happen)
+      expect(io_instance).not_to receive(:socket=)
+      doorman.call env
+    end
   end
 
   it 'stores game sessions with their hashes' do
     expect(doorman.sessions).to eq({})
     expect(io).to receive(:player?) { true }
-    game_inst = double 'game_inst'
-    expect(game).to receive(:call) { game_inst }
     doorman.call env
-    expect(doorman.sessions).to eq game_inst.hash => game_inst
+    expect(doorman.sessions).to eq game_inst.hash.to_s(16) => game_inst
   end
 end

--- a/spec/javascripts/messenger_spec.js
+++ b/spec/javascripts/messenger_spec.js
@@ -12,7 +12,8 @@ describe('Messenger', function() {
     messenger = new Messenger('ws://foo');
     messenger.socket = {
       send: function() {},
-      onmessage: messenger.socket.onmessage
+      onmessage: messenger.socket.onmessage,
+      onopen: messenger.socket.onopen
     };
     spyOn(messenger.socket, 'send');
   });
@@ -34,5 +35,13 @@ describe('Messenger', function() {
     messenger.on('foo', listener);
     messenger.socket.onmessage({ data: JSON.stringify(['foo', 'bar']) });
     expect(listener).toHaveBeenCalledWith('bar');
+  });
+
+  it('triggers `open` event when connection is open', function() {
+    listener = jasmine.createSpy('listener');
+    messenger.on('open', listener);
+    messenger.socket.onopen();
+    expect(listener).toHaveBeenCalled();
+    expect(messenger.socket.send).not.toHaveBeenCalled();
   });
 });

--- a/spec/javascripts/runner_spec.js
+++ b/spec/javascripts/runner_spec.js
@@ -1,6 +1,7 @@
 describe('JS Engine runner', function() {
   var runner;
   beforeAll(function() {
+    document.cookie = 'session_id = 0; expires=Mon, 2 May 2011 07:42:03 GMT';
     WebSocket = jasmine.createSpy('WebSocket');
     runner = new Runner();
     runner.messenger.socket = { send: function() {} }
@@ -22,6 +23,13 @@ describe('JS Engine runner', function() {
     expect(runner.messenger instanceof Messenger).toBeTruthy();
   });
 
+  it('notifies messenger when it is ready', function() {
+    listener = jasmine.createSpy('listener');
+    runner.messenger.on('display_ready', listener)
+    runner.messenger.happen('open');
+    expect(listener).toHaveBeenCalled();
+  });
+
   it('waits for acts', function() {
     expect(runner.messenger.listeners('act_start').length).not.toEqual(0);
   });
@@ -31,5 +39,18 @@ describe('JS Engine runner', function() {
     var act = { type: 'foo', subject: 'bar' };
     runner.messenger.happen('act_start', act);
     expect(runner.display.generate).toHaveBeenCalledWith(act.type, act);
+  });
+
+  it('saves session id to cookie', function() {
+    runner.messenger.happen('new_session', { hash: '12345' });
+    expect(document.cookie.match(/session_id=12345/g)).toBeTruthy();
+  });
+
+  it('send session id when it is ready', function() {
+    runner.messenger.happen('new_session', { hash: '-123foo' });
+    listener = jasmine.createSpy('listener');
+    runner.messenger.on('display_ready', listener)
+    runner.messenger.happen('open');
+    expect(listener).toHaveBeenCalledWith({ session_id: '-123foo' });
   });
 });

--- a/spec/play/run_acts_spec.rb
+++ b/spec/play/run_acts_spec.rb
@@ -36,9 +36,12 @@ RSpec.describe Tarona::Play::RunActs do
 
 
   let(:act_params) { { valid: true } }
+  let(:session) { Tardvig::HashContainer.new }
   let(:acts) { { first: FirstAct, second: SecondAct, third: ThirdAct } }
-  let :subject do 
-    described_class.new act_params: act_params, acts: acts, first_act: :first
+  let :subject do
+    described_class.new(
+      act_params: act_params, acts: acts, first_act: :first, session: session
+    )
   end
 
   describe '#call' do
@@ -61,5 +64,35 @@ RSpec.describe Tarona::Play::RunActs do
       end
       subject.call.thread.join
     end
+  end
+
+  it 'saves id of last act to session' do
+    expect(session).to receive(:[]=).with(:act, FirstAct).ordered
+    expect(session).to receive(:[]=).with(:act, SecondAct).ordered
+    expect(session).to receive(:[]=).with(:act, ThirdAct).ordered
+    subject.call.thread.join
+  end
+
+  it 'loads act from session if it is' do
+    session[:act] = SecondAct
+    expect(TestAct.ended).not_to receive(:<<).with(kind_of(FirstAct))
+    expect(TestAct.ended).to receive(:<<).with(kind_of(SecondAct)).ordered
+    expect(TestAct.ended).to receive(:<<).with(kind_of(ThirdAct)).ordered
+    subject.call.thread.join
+  end
+
+  it 'does not load act from session if there is no such act' do
+    session[:act] = Tarona::Act
+    expect(TestAct.ended).to receive(:<<).with(kind_of(FirstAct)).ordered
+    expect(TestAct.ended).to receive(:<<).with(kind_of(SecondAct)).ordered
+    expect(TestAct.ended).to receive(:<<).with(kind_of(ThirdAct)).ordered
+    subject.call.thread.join
+  end
+
+  it 'does not load act from session if there is no act in session' do
+    expect(TestAct.ended).to receive(:<<).with(kind_of(FirstAct)).ordered
+    expect(TestAct.ended).to receive(:<<).with(kind_of(SecondAct)).ordered
+    expect(TestAct.ended).to receive(:<<).with(kind_of(ThirdAct)).ordered
+    subject.call.thread.join
   end
 end

--- a/spec/play/run_acts_spec.rb
+++ b/spec/play/run_acts_spec.rb
@@ -11,11 +11,12 @@ RSpec.describe Tarona::Play::RunActs do
 
     private
 
-    def next_act
-      nil
+    def execute
+      process
     end
 
-    def notify_display
+    def next_act
+      nil
     end
   end
 

--- a/spec/play_spec.rb
+++ b/spec/play_spec.rb
@@ -1,24 +1,30 @@
 RSpec.describe Tarona::Play do
-  [:io, :tk, :tk_inst, :acts, :first_act].each { |obj| let(obj) { double } }
+  [:io, :tk, :tk_inst, :acts, :first_act, :session].each do |obj|
+    let(obj) { double(obj.to_s) }
+  end
   let(:run_acts_opts) { { io: io, acts: acts, first_act: first_act, tk: tk } }
-  let :subject do 
+  let :subject do
     described_class.new run_acts_opts
   end
-  
+
   before :example do
     allow(tk).to receive(:new).and_return(tk_inst)
+    allow(tk_inst).to receive(:session).and_return(session)
     allow(io).to receive(:spy_on)
   end
-  
+
   it 'runs acts in a cycle' do
-    expect(described_class::RunActs).to receive(:call).with(hash_including(
+    expect(described_class::RunActs).to receive(:call).with(
+      hash_including(
         acts: acts,
         first_act: first_act,
+        session: session,
         act_params: hash_including(tk: tk_inst, io: io)
-      ))
+      )
+    )
     subject.call
   end
-  
+
   it 'creates an instance of toolkit' do
     expect(tk).to receive(:new)
     subject.call

--- a/spec/websocket_spec.rb
+++ b/spec/websocket_spec.rb
@@ -89,4 +89,11 @@ RSpec.describe Tarona::WebSocket do
       end
     end
   end
+
+  it 'triggers `update_io` when socket is changed' do
+    listener = proc {}
+    expect(listener).to receive(:call)
+    io.on :update_io, &listener
+    io.socket = socket
+  end
 end


### PR DESCRIPTION
## This branch contains:

### Abstractions
*Session* - container of information about player's game progress (level, health, position, etc).

 ### Features
1. `session` container added to `Toolkit`
2. Player's latest act is automatically saved to `session`
3. Session hash is saved to cookie, so player can continue playing after refreshing the page

### Also
- Code style changed in some places to satisfy `rubocop`

## Discuss
 I do not sure whether it is good to add such a code right into the core of engine (`Doorman` and `Act`), because if there will be a lot features like this, code of the core (which must be minimalistic) will become a mess.

_It seems like nobody is interested in discussing this project, but (if anyone read this) I will be very happy if you write anything. Moreover, you do not even need to read the code below: I think that reading the text above is enough to make an opinion about the problem._
